### PR TITLE
Add user banning functionality to admin panel

### DIFF
--- a/admin-dahsboard/src/lib/supabase.ts
+++ b/admin-dahsboard/src/lib/supabase.ts
@@ -21,9 +21,10 @@ export interface WaterReport {
   assigned_to?: string;
   created_at: string;
   updated_at: string;
-  user?: { // This is a joined field, definition seems fine
+  user?: {
     email: string;
     full_name?: string;
+    is_banned?: boolean; // Added is_banned
   };
 }
 
@@ -32,5 +33,6 @@ export interface User {
   email: string;
   full_name?: string;
   role: 'user' | 'admin' | 'technician';
+  is_banned: boolean;
   created_at: string;
 }

--- a/admin-dahsboard/src/pages/Reports.tsx
+++ b/admin-dahsboard/src/pages/Reports.tsx
@@ -54,7 +54,7 @@ export function Reports() {
         .select(
           `
           *,
-          user:users(email, full_name)
+          user:users(email, full_name, is_banned)
         `
         )
         .order("created_at", { ascending: false });
@@ -525,6 +525,7 @@ export function Reports() {
                       <div>
                         <div className="text-sm font-medium text-gray-900" title={report.user?.full_name || report.user?.email || 'Anonymous'}>
                           {report.user?.full_name || report.user?.email || 'Anonymous'}
+                          {report.user?.is_banned && <span className="text-red-500 ml-1">(Banned)</span>}
                         </div>
                         {report.user?.full_name && report.user?.email && (
                           <div className="text-xs text-gray-500" title={report.user.email}>

--- a/mobile_app/types/database.ts
+++ b/mobile_app/types/database.ts
@@ -1,6 +1,7 @@
 export interface User {
   id: string;
   email: string;
+  is_banned: boolean;
   created_at: string;
 }
 


### PR DESCRIPTION
- Allows admins to ban/unban users from the Users page.
- Banned users are visually indicated on the Users page.
- Reports from banned users are marked with a (Banned) status on the Reports page.
- Requires `is_banned` (boolean, default false) column in `users` table.