### PR TITLE
Integrate mobile reporting with admin dashboard via API

### DIFF
--- a/admin-dahsboard/src/pages/Reports.tsx
+++ b/admin-dahsboard/src/pages/Reports.tsx
@@ -224,7 +224,8 @@ export function Reports() {
         throw new Error("Authentication token not found.");
       }
 
-      const response = await fetch(`${API_BASE_URL}/reports/${reportId}/status`, {
+      // Ensure this points to the general update endpoint, not /status specifically
+      const response = await fetch(`${API_BASE_URL}/reports/${reportId}`, {
         method: "PUT",
         headers: {
           "Content-Type": "application/json",

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -19,6 +19,7 @@
         "@types/express": "^5.0.3",
         "@types/node": "^24.0.10",
         "nodemon": "^3.1.10",
+        "prisma": "^6.11.0",
         "ts-node": "^10.9.2",
         "typescript": "^5.8.3"
       }
@@ -84,6 +85,66 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@prisma/config": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.11.1.tgz",
+      "integrity": "sha512-z6rCTQN741wxDq82cpdzx2uVykpnQIXalLhrWQSR0jlBVOxCIkz3HZnd8ern3uYTcWKfB3IpVAF7K2FU8t/8AQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jiti": "2.4.2"
+      }
+    },
+    "node_modules/@prisma/debug": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.11.1.tgz",
+      "integrity": "sha512-lWRb/YSWu8l4Yum1UXfGLtqFzZkVS2ygkWYpgkbgMHn9XJlMITIgeMvJyX5GepChzhmxuSuiq/MY/kGFweOpGw==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/engines": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.11.1.tgz",
+      "integrity": "sha512-6eKEcV6V8W2eZAUwX2xTktxqPM4vnx3sxz3SDtpZwjHKpC6lhOtc4vtAtFUuf5+eEqBk+dbJ9Dcaj6uQU+FNNg==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.11.1",
+        "@prisma/engines-version": "6.11.1-1.f40f79ec31188888a2e33acda0ecc8fd10a853a9",
+        "@prisma/fetch-engine": "6.11.1",
+        "@prisma/get-platform": "6.11.1"
+      }
+    },
+    "node_modules/@prisma/engines-version": {
+      "version": "6.11.1-1.f40f79ec31188888a2e33acda0ecc8fd10a853a9",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.11.1-1.f40f79ec31188888a2e33acda0ecc8fd10a853a9.tgz",
+      "integrity": "sha512-swFJTOOg4tHyOM1zB/pHb3MeH0i6t7jFKn5l+ZsB23d9AQACuIRo9MouvuKGvnDogzkcjbWnXi/NvOZ0+n5Jfw==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/fetch-engine": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.11.1.tgz",
+      "integrity": "sha512-NBYzmkXTkj9+LxNPRSndaAeALOL1Gr3tjvgRYNqruIPlZ6/ixLeuE/5boYOewant58tnaYFZ5Ne0jFBPfGXHpQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.11.1",
+        "@prisma/engines-version": "6.11.1-1.f40f79ec31188888a2e33acda0ecc8fd10a853a9",
+        "@prisma/get-platform": "6.11.1"
+      }
+    },
+    "node_modules/@prisma/get-platform": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.11.1.tgz",
+      "integrity": "sha512-b2Z8oV2gwvdCkFemBTFd0x4lsL4O2jLSx8lB7D+XqoFALOQZPa7eAPE1NU0Mj1V8gPHRxIsHnyUNtw2i92psUw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.11.1"
       }
     },
     "node_modules/@supabase/auth-js": {
@@ -1021,6 +1082,16 @@
         "ws": "*"
       }
     },
+    "node_modules/jiti": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
+      "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
+      "devOptional": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
@@ -1217,6 +1288,32 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/prisma": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.11.1.tgz",
+      "integrity": "sha512-VzJToRlV0s9Vu2bfqHiRJw73hZNCG/AyJeX+kopbu4GATTjTUdEWUteO3p4BLYoHpMS4o8pD3v6tF44BHNZI1w==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/config": "6.11.1",
+        "@prisma/engines": "6.11.1"
+      },
+      "bin": {
+        "prisma": "build/index.js"
+      },
+      "engines": {
+        "node": ">=18.18"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/proxy-addr": {

--- a/api/package.json
+++ b/api/package.json
@@ -22,6 +22,7 @@
     "@types/express": "^5.0.3",
     "@types/node": "^24.0.10",
     "nodemon": "^3.1.10",
+    "prisma": "^6.11.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.8.3"
   }

--- a/prisma/migrations/0_initial_schema/migration.sql
+++ b/prisma/migrations/0_initial_schema/migration.sql
@@ -1,0 +1,48 @@
+-- CreateEnum
+CREATE TYPE "Role" AS ENUM ('USER', 'ADMIN', 'TECHNICIAN');
+
+-- CreateEnum
+CREATE TYPE "IssueType" AS ENUM ('LEAKAGE', 'WATER_QUALITY_PROBLEM', 'OTHER');
+
+-- CreateEnum
+CREATE TYPE "Severity" AS ENUM ('LOW', 'MEDIUM', 'HIGH', 'CRITICAL');
+
+-- CreateEnum
+CREATE TYPE "ReportStatus" AS ENUM ('PENDING', 'IN_PROGRESS', 'RESOLVED');
+
+-- CreateTable
+CREATE TABLE "users" (
+    "id" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "full_name" TEXT,
+    "role" "Role" NOT NULL DEFAULT 'USER',
+    "is_banned" BOOLEAN NOT NULL DEFAULT false,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "users_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "water_reports" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "issue_type" "IssueType" NOT NULL,
+    "severity" "Severity" NOT NULL,
+    "description" TEXT NOT NULL,
+    "location_address" TEXT,
+    "latitude" DOUBLE PRECISION,
+    "longitude" DOUBLE PRECISION,
+    "image_urls" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "status" "ReportStatus" NOT NULL DEFAULT 'PENDING',
+    "assigned_to" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "water_reports_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "users_email_key" ON "users"("email");
+
+-- AddForeignKey
+ALTER TABLE "water_reports" ADD CONSTRAINT "water_reports_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;


### PR DESCRIPTION
- Added Prisma migration for initial schema.
- API: Implemented GET /reports/:id and updated PUT /reports/:id to handle status and assignment.
- Mobile App: Modified report submission to use POST /api/reports, send uppercase enums, and include auth token.
- Admin Dashboard (ReportDetails): Refactored to fetch from GET /api/reports/:id and update via PUT /api/reports/:id. Adapted to ApiWaterReport type and uppercase enums.
- Admin Dashboard (Reports): Updated status update call to use the modified PUT /api/reports/:id endpoint.