### PR TITLE
feat: add email notifications for report status updates

### DIFF
--- a/api/.env
+++ b/api/.env
@@ -12,3 +12,9 @@ SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsI
 
 # Port for the API server
 PORT=3001
+
+# Email configuration
+EMAIL_HOST="smtp.gmail.com"
+EMAIL_PORT="587"
+EMAIL_USER="your-email@gmail.com"
+EMAIL_PASS="your-app-password"

--- a/api/.env.example
+++ b/api/.env.example
@@ -12,3 +12,9 @@ SUPABASE_ANON_KEY="your-supabase-anon-key"
 
 # Port for the API server
 PORT=3001
+
+# Email configuration
+EMAIL_HOST="smtp.example.com"
+EMAIL_PORT="587"
+EMAIL_USER="user@example.com"
+EMAIL_PASS="password"

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -13,15 +13,17 @@
         "@supabase/supabase-js": "^2.50.2",
         "cors": "^2.8.5",
         "dotenv": "^17.0.1",
-        "express": "^5.1.0"
+        "express": "^5.1.0",
+        "nodemailer": "^7.0.5",
+        "prisma": "^6.11.0"
       },
       "devDependencies": {
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.3",
         "@types/node": "^24.0.10",
+        "@types/nodemailer": "^6.4.17",
         "dotenv-cli": "^8.0.0",
         "nodemon": "^3.1.10",
-        "prisma": "^6.11.0",
         "ts-node": "^10.9.2",
         "typescript": "^5.8.3"
       }
@@ -93,7 +95,6 @@
       "version": "6.11.1",
       "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.11.1.tgz",
       "integrity": "sha512-z6rCTQN741wxDq82cpdzx2uVykpnQIXalLhrWQSR0jlBVOxCIkz3HZnd8ern3uYTcWKfB3IpVAF7K2FU8t/8AQ==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "jiti": "2.4.2"
@@ -103,14 +104,12 @@
       "version": "6.11.1",
       "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.11.1.tgz",
       "integrity": "sha512-lWRb/YSWu8l4Yum1UXfGLtqFzZkVS2ygkWYpgkbgMHn9XJlMITIgeMvJyX5GepChzhmxuSuiq/MY/kGFweOpGw==",
-      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines": {
       "version": "6.11.1",
       "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.11.1.tgz",
       "integrity": "sha512-6eKEcV6V8W2eZAUwX2xTktxqPM4vnx3sxz3SDtpZwjHKpC6lhOtc4vtAtFUuf5+eEqBk+dbJ9Dcaj6uQU+FNNg==",
-      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -124,14 +123,12 @@
       "version": "6.11.1-1.f40f79ec31188888a2e33acda0ecc8fd10a853a9",
       "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.11.1-1.f40f79ec31188888a2e33acda0ecc8fd10a853a9.tgz",
       "integrity": "sha512-swFJTOOg4tHyOM1zB/pHb3MeH0i6t7jFKn5l+ZsB23d9AQACuIRo9MouvuKGvnDogzkcjbWnXi/NvOZ0+n5Jfw==",
-      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine": {
       "version": "6.11.1",
       "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.11.1.tgz",
       "integrity": "sha512-NBYzmkXTkj9+LxNPRSndaAeALOL1Gr3tjvgRYNqruIPlZ6/ixLeuE/5boYOewant58tnaYFZ5Ne0jFBPfGXHpQ==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "6.11.1",
@@ -143,7 +140,6 @@
       "version": "6.11.1",
       "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.11.1.tgz",
       "integrity": "sha512-b2Z8oV2gwvdCkFemBTFd0x4lsL4O2jLSx8lB7D+XqoFALOQZPa7eAPE1NU0Mj1V8gPHRxIsHnyUNtw2i92psUw==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "6.11.1"
@@ -329,6 +325,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.8.0"
+      }
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "6.4.17",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-6.4.17.tgz",
+      "integrity": "sha512-I9CCaIp6DTldEg7vyUTZi8+9Vo0hi1/T8gv3C89yk1rSAAzoKQ8H8ki/jBYJSFoH/BisgLP8tkZMlQ91CIquww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/phoenix": {
@@ -1159,7 +1165,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
       "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
-      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -1259,6 +1264,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.5.tgz",
+      "integrity": "sha512-nsrh2lO3j4GkLLXoeEksAMgAOqxOv6QumNRVQTJwKH4nuiww6iC2y7GyANs9kRAxCexg3+lTWM3PZ91iLlVjfg==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/nodemon": {
@@ -1387,7 +1401,6 @@
       "version": "6.11.1",
       "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.11.1.tgz",
       "integrity": "sha512-VzJToRlV0s9Vu2bfqHiRJw73hZNCG/AyJeX+kopbu4GATTjTUdEWUteO3p4BLYoHpMS4o8pD3v6tF44BHNZI1w==",
-      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/api/package.json
+++ b/api/package.json
@@ -20,12 +20,14 @@
     "cors": "^2.8.5",
     "dotenv": "^17.0.1",
     "express": "^5.1.0",
+    "nodemailer": "^7.0.5",
     "prisma": "^6.11.0"
   },
   "devDependencies": {
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.3",
     "@types/node": "^24.0.10",
+    "@types/nodemailer": "^6.4.17",
     "dotenv-cli": "^8.0.0",
     "nodemon": "^3.1.10",
     "ts-node": "^10.9.2",

--- a/api/src/lib/email.ts
+++ b/api/src/lib/email.ts
@@ -1,0 +1,34 @@
+import nodemailer from "nodemailer";
+import dotenv from "dotenv";
+
+dotenv.config();
+
+const transporter = nodemailer.createTransport({
+  host: process.env.EMAIL_HOST,
+  port: Number(process.env.EMAIL_PORT),
+  secure: false, // true for 465, false for other ports
+  auth: {
+    user: process.env.EMAIL_USER,
+    pass: process.env.EMAIL_PASS,
+  },
+});
+
+interface EmailOptions {
+  to: string;
+  subject: string;
+  html: string;
+}
+
+export const sendEmail = async (options: EmailOptions) => {
+  try {
+    const info = await transporter.sendMail({
+      from: `"Leakage App" <${process.env.EMAIL_USER}>`,
+      to: options.to,
+      subject: options.subject,
+      html: options.html,
+    });
+    console.log("Message sent: %s", info.messageId);
+  } catch (error) {
+    console.error("Error sending email:", error);
+  }
+};

--- a/api/src/routes/reportRoutes.ts
+++ b/api/src/routes/reportRoutes.ts
@@ -2,6 +2,8 @@ import { Router, Response } from "express";
 import prisma from "../lib/prisma";
 import { ReportStatus } from "@prisma/client"; // Import ReportStatus
 import { authenticateToken, AuthenticatedRequest } from "../middleware/auth";
+import { sendEmail } from "../lib/email";
+import { getReportStatusUpdateTemplate } from "../templates/reportStatusUpdate";
 
 const router = Router();
 
@@ -210,6 +212,21 @@ router.put(
           },
         },
       });
+
+      if (updatedReport.status && updatedReport.user) {
+        const { email, full_name } = updatedReport.user;
+        const emailHtml = getReportStatusUpdateTemplate(
+          full_name ?? "User",
+          updatedReport.id,
+          updatedReport.status
+        );
+        await sendEmail({
+          to: email,
+          subject: `Report ${updatedReport.id} Status Updated`,
+          html: emailHtml,
+        });
+      }
+
       res.json(updatedReport);
       return;
     } catch (error: any) {

--- a/api/src/templates/reportStatusUpdate.ts
+++ b/api/src/templates/reportStatusUpdate.ts
@@ -1,0 +1,20 @@
+export const getReportStatusUpdateTemplate = (
+  reporterName: string,
+  reportId: string,
+  newStatus: string
+) => {
+  return `
+    <!DOCTYPE html>
+    <html>
+    <head>
+      <title>Report Status Updated</title>
+    </head>
+    <body>
+      <h1>Report Status Updated</h1>
+      <p>Hello ${reporterName},</p>
+      <p>The status of your report with ID <strong>${reportId}</strong> has been updated to <strong>${newStatus}</strong>.</p>
+      <p>Thank you for using the Leakage App.</p>
+    </body>
+    </html>
+  `;
+};


### PR DESCRIPTION
This feature adds email notifications to the reporter after the report status has been updated.

- Installs nodemailer to send emails.
- Adds email configuration to environment variables.
- Creates an email service to send emails.
- Creates an email template for the report status update notification.
- Integrates the email service with the report update route.